### PR TITLE
Interpreted a Shared API router for all apps to register to.

### DIFF
--- a/backend/apps/users/urls.py
+++ b/backend/apps/users/urls.py
@@ -1,7 +1,7 @@
-from rest_framework.routers import DefaultRouter
+from backend.routers import SharedAPIRootRouter
 
 from .views import UserViewSet
 
-router = DefaultRouter()
+router = SharedAPIRootRouter()
 router.register(r'users', UserViewSet)
 urlpatterns = router.urls

--- a/backend/routers.py
+++ b/backend/routers.py
@@ -1,0 +1,14 @@
+from rest_framework.routers import DefaultRouter, SimpleRouter
+
+"""
+One shared router all apps can register.
+This results in one api-root containing all apps.
+"""
+
+
+class SharedAPIRootRouter(SimpleRouter):
+    shared_router = DefaultRouter(trailing_slash=True)
+
+    def register(self, *args, **kwargs):
+        self.shared_router.register(*args, **kwargs)
+        super().register(*args, **kwargs)

--- a/backend/urls.py
+++ b/backend/urls.py
@@ -1,12 +1,30 @@
+from django.conf import settings
 from django.conf.urls import url, include
 from django.contrib.auth.views import login
 from django.contrib import admin
 
+from backend.routers import SharedAPIRootRouter
+
 from .views import app, index
+
+"""
+http://stackoverflow.com/questions/20825029/registering-api-in-apps#22684199
+"""
+
+
+def api_urls():
+    from importlib import import_module
+    for app in settings.LOCAL_APPS:
+        try:
+            import_module(app + '.urls')
+        except (ImportError, AttributeError):
+            pass
+    return SharedAPIRootRouter.shared_router.urls
+
 
 urlpatterns = [
     url(r'^admin/', admin.site.urls),
-    url(r'^api/', include('users.urls')),
+    url(r'^api/', include(api_urls())),
     url(r'^app/', app, name='app'),
     url('^auth/login/$', login, name='login'),
     url('^$', index, name='index'),


### PR DESCRIPTION
See http://stackoverflow.com/questions/20825029/registering-api-in-apps#22684199 for the idea behind this code.

I hope you find this useful. It makes it easier for apps to register to one API endpoint
